### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
-FROM zooniverse/ruby:2.2.0
+FROM zooniverse/ruby:2.2
 
 WORKDIR /app
-
-ENV DEBIAN_FRONTEND noninteractive
 
 ADD Gemfile ./
 ADD Gemfile.lock ./
 
-RUN apt-get update && apt-get -y upgrade && \
-    bundle install
+RUN bundle install
 
 EXPOSE 80
 


### PR DESCRIPTION
We don't need to run `apt-get upgrade` any more, and we're no longer specifying exact patch versions of ruby.
