### PR TITLE
Update Experiment Server to support Comet Hunters / VOLCROWE experiment

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.libs << "tests"
+  t.test_files = FileList['tests/test*.rb']
+  t.verbose = true
+end

--- a/experiments/comet_hunters_volcrowe_experiment.rb
+++ b/experiments/comet_hunters_volcrowe_experiment.rb
@@ -1,0 +1,336 @@
+require 'plan_out'
+require 'uri'
+require 'net/http'
+require 'net/https'
+
+module PlanOut
+  class CometHuntersVolcroweExperiment1 < PlanOut::SimpleExperiment
+    @@SUGAR_STAGING_URL = "https://notifications-staging.zooniverse.org/experiment"
+    @@SUGAR_PRODUCTION_URL = "https://notifications.zooniverse.org/experiment"
+    @@SUGAR_URL = !ENV["SUGAR_HOST"].nil? ? "#{ENV["SUGAR_HOST"]}/experiment" : @@SUGAR_STAGING_URL
+    @@SUGAR_USERNAME = ENV["SUGAR_USERNAME"]
+    @@SUGAR_PASSWORD = ENV["SUGAR_PASSWORD"]
+    @@PRODUCTION_EXPERIMENT_SERVER = "http://experiments.zooniverse.org/"
+    @@ENV = Assignment.new(@@PRODUCTION_EXPERIMENT_SERVER) # seed for random assignment to cohorts
+    @@COHORT_CONTROL = "control"
+    @@COHORT_QUESTIONS = "questions"
+    @@COHORT_STATEMENTS = "statements"
+    @@COHORT_INELIGIBLE = "(ineligible)"
+    @@ANONYMOUS = "(anonymous)"
+    @@PROJECT_SLUG_PRODUCTION = "mschwamb/comet-hunters"
+    @@PROJECT_SLUG_DEVELOPMENT = "mschwamb/planet-four-terrains"
+    @@EXPERIMENT_NAME = "CometHuntersVolcroweExperiment1"
+    @@CLASSIFICATION_MARKER = "classification"
+
+    def setup
+      if @@SUGAR_URL == @@SUGAR_PRODUCTION_URL
+        @@PROJECT_SLUG = @@PROJECT_SLUG_PRODUCTION
+      else
+        @@PROJECT_SLUG = @@PROJECT_SLUG_DEVELOPMENT
+      end
+    end
+
+    def self.getExperimentName
+      @@EXPERIMENT_NAME
+    end
+
+    def self.getControlCohort
+      @@COHORT_CONTROL
+    end
+
+    def self.getStatementsCohort
+      @@COHORT_STATEMENTS
+    end
+
+    def self.getQuestionsCohort
+      @@COHORT_QUESTIONS
+    end
+
+    def self.ensureNotArray(jsonString)
+      if jsonString!=""
+        obj = JSON.parse(jsonString.dup)
+        if obj.kind_of?(Array) and obj.length==1
+          obj = obj[0]
+        end
+        obj.to_json
+      else
+        jsonString
+      end
+    end
+
+    def self.projects
+      [@@PROJECT_SLUG]
+    end
+
+    def self.getCohort(user_id)
+      if user_id==@@ANONYMOUS or defined?(user_id)==nil or user_id.nil?
+        @@COHORT_INELIGIBLE
+      else
+        UniformChoice.new({
+          choices: [@@COHORT_CONTROL,@@COHORT_QUESTIONS,@@COHORT_STATEMENTS],
+          unit: user_id
+        }).execute(@@ENV)
+      end
+    end
+
+    def self.getInterventionsAvailable(cohort)
+      case cohort
+      when @@COHORT_CONTROL then []
+      when @@COHORT_QUESTIONS then [
+        "valued-question-1",
+        "valued-question-2",
+        "valued-question-3",
+        "valued-question-4",
+        "valued-question-5",
+        "gamisation-question-1",
+        "gamisation-question-2",
+        "gamisation-question-3",
+        "gamisation-question-4",
+        "gamisation-question-5",
+        "learning-question-1",
+        "learning-question-2",
+        "learning-question-3",
+        "learning-question-4",
+        "learning-question-5"]
+      when @@COHORT_STATEMENTS then [
+        "valued-statement-1",
+        "valued-statement-2",
+        "valued-statement-3",
+        "valued-statement-4",
+        "valued-statement-5",
+        "gamisation-statement-1",
+        "gamisation-statement-2",
+        "gamisation-statement-3",
+        "gamisation-statement-4",
+        "gamisation-statement-5",
+        "learning-statement-1",
+        "learning-statement-2",
+        "learning-statement-3",
+        "learning-statement-4",
+        "learning-statement-5"]
+      else []
+      end
+    end
+
+    def self.registerParticipant(user_id)
+      cohort = CometHuntersVolcroweExperiment1::getCohort(user_id)
+      creation_params = {
+            experiment_name:                @@EXPERIMENT_NAME,
+            project_slug:                   @@PROJECT_SLUG,
+            cohort:                         cohort,
+            user_id:                        user_id,
+            active:                         true,
+            excluded:                       false,
+            excluded_reason:                nil,
+            interventions_available:        [],
+            interventions_seen:             [],
+            original_session_plans:         Hash.new,
+            session_histories:              Hash.new,
+            current_session_id:             nil,
+            current_session_history:        [],
+            current_session_plan:           [],
+            seq_of_next_event:              -1,
+            intervention_time:              false,
+            next_event:                     @@CLASSIFICATION_MARKER
+      }
+      if cohort
+        creation_params[:interventions_available] = CometHuntersVolcroweExperiment1::getInterventionsAvailable(cohort)
+      else
+        creation_params[:active] = false
+        creation_params[:excluded] = true
+        creation_params[:excluded_reason] = "No cohort available for user."
+      end
+      Participant.create(creation_params)
+    end
+
+    # get the participant for this user ID, registering the user first if they are not already registered
+    def self.getParticipant(user_id)
+      participant = Participant.where( experiment_name:@@EXPERIMENT_NAME , user_id:user_id ).first
+      if not participant.present?
+        participant = CometHuntersVolcroweExperiment1::registerParticipant(user_id)
+      end
+      participant
+    end
+
+    # pick a random number of classifications that need to occur before the first intervention
+    def self.getClassificationsBeforeFirstIntervention(cohort)
+      after = -1
+      case cohort
+      when @@COHORT_QUESTIONS
+        # after 6th classification +/- 2
+        after = rand(4..8)
+      when @@COHORT_STATEMENTS
+        # after 4th classification +/- 2
+        after = rand(2..6)
+      end
+      after
+    end
+
+    # pick a random number of classifications that need to occur before the next intervention
+    def self.getClassificationsBeforeNextIntervention(cohort)
+      after = -1
+      case cohort
+      when @@COHORT_QUESTIONS
+        # after 8 more classifications +/- 2
+        after = rand(6..10)
+      when @@COHORT_STATEMENTS
+        # after 6 more classifications +/- 2
+        after = rand(4..8)
+      end
+      after
+    end
+
+    # generate a random session plan according to cohort, long enough to use up all available interventions
+    def self.generateSessionPlan(cohort, available_interventions)
+      session_plan = []
+      interventions = available_interventions.dup.shuffle
+      if interventions.length > 0
+        first_intervention = interventions.pop()
+        classifications_before_first = CometHuntersVolcroweExperiment1::getClassificationsBeforeFirstIntervention(cohort)
+        if classifications_before_first > -1
+          classifications_before_first.times { session_plan.push(@@CLASSIFICATION_MARKER) }
+          session_plan.push(first_intervention)
+          while interventions.length > 0
+            next_intervention = interventions.pop()
+            classifications_before_next = CometHuntersVolcroweExperiment1::getClassificationsBeforeNextIntervention(cohort)
+            if classifications_before_next > -1
+              classifications_before_next.times { session_plan.push(@@CLASSIFICATION_MARKER) }
+              session_plan.push(next_intervention)
+            else
+              session_plan = []
+              break
+            end
+          end
+          return session_plan
+        end
+      end
+      return []
+    end
+
+    # start a new session (or restart the session)
+    def self.startOrRestartSession(participant, session_id)
+      # archive the session history for the previous session
+      if !participant.current_session_id.nil?
+        participant.session_histories[participant.current_session_id] = participant.current_session_history.dup
+      end
+
+      # back up first non-nil session plan for each session_id
+      if !participant.current_session_id.nil? and !participant.current_session_plan.nil? and !participant.original_session_plans.key?(participant.current_session_id)
+        participant.original_session_plans[participant.current_session_id] = participant.current_session_plan
+      end
+
+      # if not a restart, clear the current session log and mark that we are now in the new session
+      if participant.current_session_id != session_id
+        participant.current_session_history = []
+        participant.current_session_id = session_id
+      end
+
+      # generate a new plan for this session, and point to the start of it
+      participant.current_session_plan = CometHuntersVolcroweExperiment1::generateSessionPlan(participant.cohort, participant.interventions_available)
+      if participant.current_session_plan.length > 0
+        participant.seq_of_next_event = 0
+      end
+    end
+
+    # ensure that participant data is set up correctly according to the provided session ID
+    def self.verifySession(participant, session_id)
+      if participant.current_session_id.nil? or participant.current_session_id != session_id
+        # new session
+        CometHuntersVolcroweExperiment1::startOrRestartSession(participant, session_id)
+      end
+    end
+
+    # if the next entry in the session plan matches the event we just completed, advance.
+    def self.advanceIfNextEventSatisfied(this_event, participant, session_id)
+      if (participant.cohort == @@COHORT_QUESTIONS or participant.cohort == @@COHORT_STATEMENTS)
+        if this_event == @@CLASSIFICATION_MARKER and participant.next_event == @@CLASSIFICATION_MARKER
+          # expected classification satisfied
+          participant.seq_of_next_event += 1
+        elsif this_event == participant.next_event
+          # expected intervention satisfied
+          participant.seq_of_next_event += 1
+        else
+          # mismatch - it is recorded but we do not advance.
+
+          # if we encountered an intervention, that features in the session plan somewhere in the future,
+          # we have to come up with a new session plan for this session, excluding that intervention
+          # (Note: it has already been marked unavailable so just regenerating a new plan is sufficient).
+          if this_event != @@CLASSIFICATION_MARKER and participant.current_session_plan[participant.seq_of_next_event..-1].include?(this_event)
+            CometHuntersVolcroweExperiment1::startOrRestartSession(participant, session_id)
+          end
+        end
+
+        participant.next_event = participant.current_session_plan[participant.seq_of_next_event]
+        participant.intervention_time = (participant.next_event != @@CLASSIFICATION_MARKER)
+      else
+        participant.next_event = @@CLASSIFICATION_MARKER
+        participant.intervention_time = false
+      end
+
+      # check for end of experiment (ie completion of last intervention)
+      if (participant.cohort == @@COHORT_QUESTIONS or participant.cohort == @@COHORT_STATEMENTS) and participant.seq_of_next_event >= participant.current_session_plan.length
+        # session plan complete
+        participant.active = true # for this experiment, we're keeping partipants active after completing the session plan.
+                                  # Change this line (and tests) if that is not what is wanted.
+        participant.next_event = nil
+        participant.intervention_time = false
+      end
+    end
+
+    def self.getJSONPostBodyForSugar(participant)
+      {experiments: [{
+        user_id: participant.user_id,
+        message: participant,
+        section: @@PROJECT_SLUG,
+        delivered: false
+      }]}.to_json
+    end
+
+    def self.postLatestToSugar(participant, session_id)
+      uri = URI(@@SUGAR_URL)
+      https = Net::HTTP.new(uri.host,uri.port)
+      https.use_ssl = true
+      req = Net::HTTP::Post.new(uri.path, initheader = {'Content-Type' => 'application/json'})
+      req.basic_auth @@SUGAR_USERNAME, @@SUGAR_PASSWORD
+      req.body = CometHuntersVolcroweExperiment1::getJSONPostBodyForSugar(participant)
+      response = https.request(req)
+      body = CometHuntersVolcroweExperiment1::ensureNotArray(response.body)
+      [response.code, body] # response.body is a json string
+    end
+
+    # upon notification that a classification has ended, update participant and post latest data to Sugar
+    def self.endClassification(user_id, session_id, classification_id)
+      # ensure the user is registered
+      participant = CometHuntersVolcroweExperiment1::getParticipant(user_id)
+      CometHuntersVolcroweExperiment1::verifySession(participant, session_id)
+      participant.current_session_history.push "classification:#{classification_id}"
+      CometHuntersVolcroweExperiment1::advanceIfNextEventSatisfied(@@CLASSIFICATION_MARKER, participant, session_id)
+      sugar_response = CometHuntersVolcroweExperiment1::postLatestToSugar(participant,session_id) # returns json
+      participant.save!
+      sugar_response
+    end
+
+    # upon notification that an intervention has ended, update participant and post latest data to Sugar
+    def self.endIntervention(user_id, session_id, intervention_id)
+      # ensure the user is registered
+      participant = CometHuntersVolcroweExperiment1::getParticipant(user_id)
+      participant.interventions_available.delete intervention_id
+      participant.interventions_seen.push intervention_id
+      CometHuntersVolcroweExperiment1::verifySession(participant, session_id)
+      participant.current_session_history.push "intervention:#{intervention_id}"
+      CometHuntersVolcroweExperiment1::advanceIfNextEventSatisfied(intervention_id, participant, session_id)
+      sugar_response = CometHuntersVolcroweExperiment1::postLatestToSugar(participant,session_id) # returns json
+      participant.save!
+      sugar_response
+    end
+
+    #def assign(params, **inputs)
+    #  userid = inputs[:userid]
+    #
+    #  params[:cohort] = UniformChoice.new({
+    #    choices: [@@COHORT_CONTROL, @@COHORT_QUESTIONS, @@COHORT_STATEMENTS],
+    #    unit: userid
+    #  })
+    #end
+  end
+end

--- a/models/intervention_opt_out.rb
+++ b/models/intervention_opt_out.rb
@@ -6,7 +6,7 @@ class InterventionOptOut
   field :project, type: String
   field :opted_out, type: Boolean, default: false
 
-  validates_inclusion_of :project, in: [ "galaxy_zoo" ], message: "Not a recognized project name. Supported project names are: galaxy_zoo"
+  validates_inclusion_of :project, in: [ "galaxy_zoo", "mschwamb/comet-hunters" ], message: "Not a recognized project name. Supported project names are: galaxy_zoo, mschwamb/comet-hunters"
   validates_presence_of :experiment_name, message: "Experiment name must be specified"
 
   def as_json(args)

--- a/models/participant.rb
+++ b/models/participant.rb
@@ -1,15 +1,22 @@
 class Participant
     include Mongoid::Document
     field :experiment_name, type: String
+    field :project_slug, type: String
     field :cohort, type: String
     field :user_id, type: String
     field :active, type: Mongoid::Boolean
-    field :non_blank_subjects_seen, type: Array
-    field :blank_subjects_seen, type: Array
-    field :non_blank_subjects_available, type: Array
-    field :blank_subjects_available, type: Array
     field :excluded, type: Mongoid::Boolean
     field :excluded_reason, type: String
+    field :interventions_available, type: Array
+    field :interventions_seen, type: Array
+    field :original_session_plans, type: Hash
+    field :session_histories, type: Hash
+    field :current_session_id, type: String
+    field :current_session_history, type: Array
+    field :current_session_plan, type: Array
+    field :seq_of_next_event, type: Integer
+    field :intervention_time, type: Mongoid::Boolean
+    field :next_event, type: String
 
     def as_json(args)
         result = super(args)

--- a/server.rb
+++ b/server.rb
@@ -2,6 +2,8 @@ require 'sinatra'
 require 'json'
 require_relative 'environment'
 
+###### Main API: Cohort Determination and Participant Registration
+
 def active_experiments
   experiments = PlanOut.constants.collect{|experiment| experiment.to_s}.select{|experiment_name| experiment_name.include? "Experiment" }
   experiments - ["SimpleExperiment", "Experiment"]
@@ -325,7 +327,36 @@ post '/users/:user_id/optout' do
   opt_out_results.to_json
 end
 
-###### Experimental Participant API
+###### Participant API for Sugar-based Experiments - Specific to Comet Hunters Experiment
+
+# accept notification that a classification has finished, update participant and push latest to Sugar (and return it)
+post '/experiment/:experiment_name/user/:user_id/session/:session_id/classification/:classification_id' do
+  content_type :json
+  headers \
+    "Access-Control-Allow-Origin"   => "*",
+    "Access-Control-Expose-Headers" => "Access-Control-Allow-Origin"
+  experiment = get_experiment(params[:experiment_name]).new
+  result = experiment.class.endClassification(params[:user_id], params[:session_id], params[:classification_id])
+  status result[0]
+  body = result[1]
+  body
+end
+
+# accept notification that an intervention has finished, update participant and push latest to Sugar (and return it)
+post '/experiment/:experiment_name/user/:user_id/session/:session_id/intervention/:intervention_id' do
+  content_type :json
+  headers \
+    "Access-Control-Allow-Origin"   => "*",
+    "Access-Control-Expose-Headers" => "Access-Control-Allow-Origin"
+  experiment = get_experiment(params[:experiment_name]).new
+  result = experiment.class.endIntervention(params[:user_id], params[:session_id], params[:intervention_id])
+  status result[0]
+  body = result[1]
+  body
+end
+
+###### Experimental Participant API - Specific to Serengeti Blanks Experiment
+
 ###### At the moment this only works for an experiment based around maintaining a set list of random & inserted subjects per user, but could be generalized.
 
 get '/experiment/:experiment_name/participants' do

--- a/tests/test_volcrowe_experiment_basics.rb
+++ b/tests/test_volcrowe_experiment_basics.rb
@@ -1,0 +1,144 @@
+# Note: These are not really unit tests - in fact they are external tests.
+# They assume you have already started a server with `ruby server.rb -o 0.0.0.0`
+
+require "test/unit"
+require 'net/http'
+require 'uri'
+require_relative '../experiments/comet_hunters_volcrowe_experiment.rb'
+require 'json'
+
+class TestVolcroweExperimentBasics < Test::Unit::TestCase
+
+    include PlanOut
+
+    @@SERVER_URL = "http://localhost:4567"
+    @@TEST_CONTROL_USER_ID = "TEST_USER"
+    @@TEST_STATEMENTS_USER_ID = "TEST_USER_1"
+    @@TEST_QUESTIONS_USER_ID = "TEST_USER_2"
+    @@FIRST_SESSION_ID = "TEST_SESSION_1"
+    @@SECOND_SESSION_ID = "TEST_SESSION_2"
+    @@CLASSIFICATION_MARKER = "classification"
+    @@CLASSIFICATION_IDS = []
+
+    def setup
+      @@CLASSIFICATION_IDS = []
+      100.times do |i|
+        @@CLASSIFICATION_IDS.push (i+101)
+      end
+    end
+
+    def testThatExperimentNameIsAvailableAndCorrect
+      experimentName = CometHuntersVolcroweExperiment1::getExperimentName
+      assert_equal(experimentName,"CometHuntersVolcroweExperiment1")
+    end
+
+    def testThatExperimentIsLoaded
+      uri = URI.parse("#{@@SERVER_URL}/active_experiments")
+      http = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTP::Get.new(uri.request_uri)
+      response = http.request(request)
+      assert_equal("200",response.code)
+      exps = response.body
+      assert(exps.include?(CometHuntersVolcroweExperiment1::getExperimentName),"Expected to find '#{CometHuntersVolcroweExperiment1::getExperimentName}'")
+    end
+
+    def testClassificationForNewStatementsUser
+      uri = URI.parse("#{@@SERVER_URL}/experiment/CometHuntersVolcroweExperiment1/user/#{@@TEST_STATEMENTS_USER_ID}/session/#{@@FIRST_SESSION_ID}/classification/#{@@CLASSIFICATION_IDS[0]}")
+      http = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTP::Post.new(uri.request_uri)
+      begin
+        response = http.request(request)
+        assert_equal("200",response.code)
+        data = JSON.parse(response.body)
+        assert_equal(CometHuntersVolcroweExperiment1::getExperimentName,data["message"]["experiment_name"],"Wrong experiment name.")
+        assert_equal(CometHuntersVolcroweExperiment1::getStatementsCohort,data["message"]["cohort"],"Wrong cohort.")
+        assert_equal(@@TEST_STATEMENTS_USER_ID,data["message"]["user_id"],"Wrong user ID.")
+        assert(data["message"]["active"]==true,"Expected participant to be active.")
+        assert(data["message"]["excluded"]==false,"Expected participant not to be excluded.")
+        assert_nil(data["message"]["excluded_reason"],"Expected no exclusion reason")
+        assert_equal(15,data["message"]["interventions_available"].length,"Expected 15 available interventions.")
+        assert_equal(0,data["message"]["interventions_seen"].length,"Expected no seen interventions.")
+        assert_equal(Hash.new, data["message"]["original_session_plans"],"Expected no original session plans.")
+        assert_equal(Hash.new, data["message"]["session_histories"],"Expected no session histories.")
+        assert_equal(@@FIRST_SESSION_ID, data["message"]["current_session_id"],"Wrong session ID.")
+        assert_equal(["classification:#{@@CLASSIFICATION_IDS[0]}"], data["message"]["current_session_history"],"Expected empty current session history.")
+        assert_not_equal(0, data["message"]["current_session_plan"].length,"Expected a non-empty session plan.")
+        assert(data["message"]["current_session_plan"].length>30,"Expected a session plan longer than 30 events.")
+        assert_equal(1, data["message"]["seq_of_next_event"],"Expected to be pointing to second event in session plan.")
+        assert_equal(false,data["message"]["intervention_time"],"Expected to be told that an intervention is not due next.")
+        assert_equal(@@CLASSIFICATION_MARKER,data["message"]["next_event"],"Expected to be told that the next event is a classification.")
+      ensure
+        deleteUser(@@TEST_STATEMENTS_USER_ID)
+      end
+    end
+
+    def testClassificationForNewQuestionsUser
+      uri = URI.parse("#{@@SERVER_URL}/experiment/CometHuntersVolcroweExperiment1/user/#{@@TEST_QUESTIONS_USER_ID}/session/#{@@FIRST_SESSION_ID}/classification/#{@@CLASSIFICATION_IDS[0]}")
+      http = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTP::Post.new(uri.request_uri)
+      begin
+        response = http.request(request)
+        assert_equal("200",response.code)
+        data = JSON.parse(response.body)
+        assert_equal(CometHuntersVolcroweExperiment1::getExperimentName,data["message"]["experiment_name"],"Wrong experiment name.")
+        assert_equal(CometHuntersVolcroweExperiment1::getQuestionsCohort,data["message"]["cohort"],"Wrong cohort.")
+        assert_equal(@@TEST_QUESTIONS_USER_ID,data["message"]["user_id"],"Wrong user ID.")
+        assert(data["message"]["active"]==true,"Expected participant to be active.")
+        assert(data["message"]["excluded"]==false,"Expected participant not to be excluded.")
+        assert_nil(data["message"]["excluded_reason"],"Expected no exclusion reason")
+        assert_equal(15,data["message"]["interventions_available"].length,"Expected 15 available interventions.")
+        assert_equal(0,data["message"]["interventions_seen"].length,"Expected no seen interventions.")
+        assert_equal(Hash.new, data["message"]["original_session_plans"],"Expected no original session plans.")
+        assert_equal(Hash.new, data["message"]["session_histories"],"Expected no session histories.")
+        assert_equal(@@FIRST_SESSION_ID, data["message"]["current_session_id"],"Wrong session ID.")
+        assert_equal(["classification:#{@@CLASSIFICATION_IDS[0]}"], data["message"]["current_session_history"],"Expected empty current session history.")
+        assert_not_equal(0, data["message"]["current_session_plan"].length,"Expected a non-empty session plan.")
+        assert(data["message"]["current_session_plan"].length>30,"Expected a session plan longer than 30 events.")
+        assert_equal(1, data["message"]["seq_of_next_event"],"Expected to be pointing to second event in session plan.")
+        assert_equal(false,data["message"]["intervention_time"],"Expected to be told that an intervention is not due next.")
+        assert_equal(@@CLASSIFICATION_MARKER,data["message"]["next_event"],"Expected to be told that the next event is a classification.")
+      ensure
+        deleteUser(@@TEST_QUESTIONS_USER_ID)
+      end
+    end
+
+    def testClassificationForNewControlUser
+      uri = URI.parse("#{@@SERVER_URL}/experiment/CometHuntersVolcroweExperiment1/user/#{@@TEST_CONTROL_USER_ID}/session/#{@@FIRST_SESSION_ID}/classification/#{@@CLASSIFICATION_IDS[0]}")
+      http = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTP::Post.new(uri.request_uri)
+      begin
+        response = http.request(request)
+        assert_equal("200",response.code)
+        data = JSON.parse(response.body)
+        assert_equal(CometHuntersVolcroweExperiment1::getExperimentName,data["message"]["experiment_name"],"Wrong experiment name.")
+        assert_equal(CometHuntersVolcroweExperiment1::getControlCohort,data["message"]["cohort"],"Wrong cohort.")
+        assert_equal(@@TEST_CONTROL_USER_ID,data["message"]["user_id"],"Wrong user ID.")
+        assert_equal(true,data["message"]["active"],"Expected participant to be active.")
+        assert_equal(false,data["message"]["excluded"],"Expected participant not to be excluded.")
+        assert_nil(data["message"]["excluded_reason"],"Expected no exclusion reason")
+        assert_equal(0,data["message"]["interventions_available"].length,"Expected no available interventions.")
+        assert_equal(0,data["message"]["interventions_seen"].length,"Expected no seen interventions.")
+        assert_equal(Hash.new, data["message"]["original_session_plans"],"Expected no original session plans.")
+        assert_equal(Hash.new, data["message"]["session_histories"],"Expected no session histories.")
+        assert_equal(@@FIRST_SESSION_ID, data["message"]["current_session_id"],"Wrong session ID.")
+        assert_equal(["classification:#{@@CLASSIFICATION_IDS[0]}"], data["message"]["current_session_history"],"Expected empty current session history.")
+        assert_equal(0, data["message"]["current_session_plan"].length,"Expected an empty session plan.")
+        assert_equal(-1, data["message"]["seq_of_next_event"],"Expected no valid pointer in session plan.")
+        assert_equal(false,data["message"]["intervention_time"],"Expected to be told that an intervention is not not due next.")
+        assert_equal(@@CLASSIFICATION_MARKER,data["message"]["next_event"],"Expected to be told that the next event is a classification.")
+      ensure
+        deleteUser(@@TEST_CONTROL_USER_ID)
+      end
+    end
+
+## Helper methods
+    def deleteUser(user_id)
+      uri = URI.parse("#{@@SERVER_URL}/experiment/CometHuntersVolcroweExperiment1/participant/#{user_id}")
+      http = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTP::Delete.new(uri.request_uri)
+      response = http.request(request)
+      assert_equal("200",response.code)
+    end
+##
+
+end

--- a/tests/test_volcrowe_experiment_seq.rb
+++ b/tests/test_volcrowe_experiment_seq.rb
@@ -1,0 +1,256 @@
+# Note: These are not really unit tests - in fact they are external tests.
+# They assume you have already started a server with:
+#   SUGAR_HOST=... SUGAR_USERNAME=... SUGAR_PASSWORD=`...` ruby server.rb -o 0.0.0.0
+# (or modify this IP if you change @@SERVER_URL)
+
+require "test/unit"
+require 'net/http'
+require 'uri'
+require_relative '../experiments/comet_hunters_volcrowe_experiment.rb'
+require 'json'
+
+class TestVolcroweExperimentSeq < Test::Unit::TestCase
+
+    include PlanOut
+
+    @@SERVER_URL = "http://localhost:4567"
+    @@TEST_CONTROL_USER_ID = "TEST_USER"
+    @@TEST_STATEMENTS_USER_ID = "TEST_USER_1"
+    @@TEST_QUESTIONS_USER_ID = "TEST_USER_2"
+    @@FIRST_SESSION_ID = "TEST_SESSION_1"
+    @@SECOND_SESSION_ID = "TEST_SESSION_2"
+    @@CLASSIFICATION_MARKER = "classification"
+    @@CLASSIFICATION_IDS = []
+
+    def setup
+      @@CLASSIFICATION_IDS = []
+      1000.times do |i|
+        @@CLASSIFICATION_IDS.push (i+101)
+      end
+    end
+
+#   If the testFullExperiment tests below fail, disable these and enable these simpler/subset ones instead - easier to debug.
+#
+#    def testUpToFirstInterventionForANewStatementsUser
+#      handleTestUpToFirstIntervention @@TEST_STATEMENTS_USER_ID, 15, CometHuntersVolcroweExperiment1::getStatementsCohort
+#    end
+#
+#    def testUpToFirstInterventionForANewQuestionsUser
+#      handleTestUpToFirstIntervention @@TEST_QUESTIONS_USER_ID, 15, CometHuntersVolcroweExperiment1::getQuestionsCohort
+#    end
+#
+#    def testUpToFirstInterventionForANewControlUser
+#      handleTestUpToFirstIntervention @@TEST_CONTROL_USER_ID, 0, CometHuntersVolcroweExperiment1::getControlCohort
+#    end
+
+    def testFullExperimentForANewControlUser
+      handleTestFullExperiment @@TEST_CONTROL_USER_ID, 0, CometHuntersVolcroweExperiment1::getControlCohort
+    end
+
+    def testFullExperimentForANewStatementsUser
+      handleTestFullExperiment @@TEST_STATEMENTS_USER_ID, 15, CometHuntersVolcroweExperiment1::getStatementsCohort
+    end
+
+    def testFullExperimentForANewQuestionsUser
+      handleTestFullExperiment @@TEST_QUESTIONS_USER_ID, 15, CometHuntersVolcroweExperiment1::getQuestionsCohort
+    end
+
+## Helper methods
+
+    def deleteUser(user_id)
+      uri = URI.parse("#{@@SERVER_URL}/experiment/CometHuntersVolcroweExperiment1/participant/#{user_id}")
+      http = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTP::Delete.new(uri.request_uri)
+      response = http.request(request)
+      assert_equal("200",response.code)
+    end
+
+    def handleTestFullExperiment(user_id, expected_available_interventions, expected_cohort)
+      classification_id_index = 0
+      interventions_available_count = expected_available_interventions
+      interventions_seen_count = 0
+      begin
+        data = postClassification user_id, classification_id_index
+        seq, classification_id_index, session_plan, nextEvent, current_session_history = advanceExpectationsAfterClassification data, seq, session_plan, nextEvent, current_session_history, classification_id_index
+        interventions_available_count.times do |i|
+          # print "\nStarting classifications + interventions loop for intervention #{i}\n"
+          data, seq, classification_id_index, session_plan, nextEvent, current_session_history, interventions_available_count, interventions_seen_count = handleABlockOfClassificationsThenAnIntervention data, session_plan, seq, classification_id_index, nextEvent, current_session_history, interventions_available_count, interventions_seen_count, user_id, expected_cohort
+        end
+      ensure
+        deleteUser(user_id)
+      end
+    end
+
+    def handleTestUpToFirstIntervention(user_id, expected_available_interventions, expected_cohort)
+      classification_id_index = 0
+      interventions_available_count = expected_available_interventions
+      interventions_seen_count = 0
+      begin
+        data = postClassification user_id, classification_id_index
+        seq, classification_id_index, session_plan, nextEvent, current_session_history = advanceExpectationsAfterClassification data, seq, session_plan, nextEvent, current_session_history, classification_id_index
+        data, seq, classification_id_index, session_plan, nextEvent, current_session_history, interventions_available_count, interventions_seen_count = handleABlockOfClassificationsThenAnIntervention data, session_plan, seq, classification_id_index, nextEvent, current_session_history, interventions_available_count, interventions_seen_count, user_id, expected_cohort
+      ensure
+        deleteUser(user_id)
+      end
+    end
+
+    def handleABlockOfClassificationsThenAnIntervention(data, session_plan, seq, classification_id_index, nextEvent, current_session_history, interventions_available_count, interventions_seen_count, user_id, expected_cohort)
+      while nextEvent==@@CLASSIFICATION_MARKER
+        data, seq, classification_id_index, session_plan, nextEvent, current_session_history, interventions_available_count, interventions_seen_count = handleClassificationWithChecks data, session_plan, seq, classification_id_index, nextEvent, current_session_history, interventions_available_count, interventions_seen_count, user_id
+      end
+      while nextEvent!=@@CLASSIFICATION_MARKER and not nextEvent.nil?
+        data, seq, interventions_available_count, interventions_seen_count, current_session_history, nextEvent = handleInterventionWithChecks data, session_plan, seq, current_session_history, interventions_available_count, interventions_seen_count, nextEvent, user_id, expected_cohort
+      end
+      return data, seq, classification_id_index, session_plan, nextEvent, current_session_history, interventions_available_count, interventions_seen_count
+    end
+
+    def handleClassificationWithChecks(data, session_plan, seq, classification_id_index, nextEvent, current_session_history, interventions_available_count, interventions_seen_count, user_id)
+      preCheckClassification data, session_plan, seq, current_session_history, nextEvent
+      data = postClassification user_id, classification_id_index
+      seq, classification_id_index, session_plan, nextEvent, current_session_history = advanceExpectationsAfterClassification data, seq, session_plan, nextEvent, current_session_history, classification_id_index
+      postCheckClassification seq, data, session_plan, classification_id_index, current_session_history, nextEvent
+      return data, seq, classification_id_index, session_plan, nextEvent, current_session_history, interventions_available_count, interventions_seen_count
+    end
+
+    def handleInterventionWithChecks(data, session_plan, seq, current_session_history, interventions_available_count, interventions_seen_count, nextEvent, user_id, expected_cohort)
+      preCheckIntervention data, session_plan, seq, current_session_history, nextEvent
+      intervention_to_post = session_plan[seq]
+      data = postIntervention intervention_to_post, current_session_history, user_id
+      seq, interventions_available_count, interventions_seen_count, current_session_history, nextEvent = advanceExpectationsAfterIntervention data, seq, current_session_history, intervention_to_post, interventions_available_count, interventions_seen_count, session_plan, nextEvent
+      postCheckIntervention data, interventions_available_count, interventions_seen_count, intervention_to_post, current_session_history, seq, session_plan, nextEvent, user_id, expected_cohort
+      return data, seq, interventions_available_count, interventions_seen_count, current_session_history, nextEvent
+    end
+
+    def preCheckClassification(data, session_plan, seq, current_session_history, nextEvent)
+      context = getContextForAssert "preCheckClassification", session_plan, seq, current_session_history, nextEvent, data["message"]["intervention_time"]
+      assert_equal(false,data["message"]["intervention_time"],"#{context}Expected to be told that an intervention is not due next.")
+      assert_equal(@@CLASSIFICATION_MARKER,data["message"]["next_event"],"#{context}Expected to be told that the next event is a classification.")
+      assert_equal(session_plan[seq],data["message"]["next_event"],"#{context}Expected next event in session plan to also be in next_event.")
+    end
+
+    def postCheckClassification(seq, data, session_plan, classification_id_index, current_session_history, nextEvent)
+      context = getContextForAssert "postCheckClassification", session_plan, seq, current_session_history, nextEvent, data["message"]["intervention_time"]
+      assert_equal(@@FIRST_SESSION_ID,data["message"]["current_session_id"], "#{context}Expected session ID not to change.")
+      assert_equal(seq,data["message"]["seq_of_next_event"],"#{context}Expected session plan pointer to advance.")
+      assert_equal(session_plan,data["message"]["current_session_plan"],"#{context}Expected session plan not to change.")
+    end
+
+    def postClassification(user_id, classification_id_index)
+      assert(!@@CLASSIFICATION_IDS[classification_id_index].nil?, "Expected to find a classification ID with index #{classification_id_index} for use in testing.")
+      url = "#{@@SERVER_URL}/experiment/CometHuntersVolcroweExperiment1/user/#{user_id}/session/#{@@FIRST_SESSION_ID}/classification/#{@@CLASSIFICATION_IDS[classification_id_index]}"
+      uri = URI.parse(url)
+      http = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTP::Post.new(uri.request_uri)
+      response = http.request(request)
+      assert_equal("200",response.code, "Expected POST of classification to succeed. Tried to post to #{url}. Message from server: #{response.code} - #{response.message} Response body:\n #{response.body}")
+      JSON.parse(response.body)
+    end
+
+    def preCheckIntervention(data, session_plan, seq, current_session_history, nextEvent)
+      context = getContextForAssert "preCheckIntervention", session_plan, seq, current_session_history, nextEvent, data["message"]["intervention_time"]
+      assert_equal(true,data["message"]["intervention_time"],"#{context}Expected to be told that an intervention is due next.")
+      assert_not_equal(@@CLASSIFICATION_MARKER,data["message"]["next_event"],"#{context}Expected to be told that the next event is an intervention.")
+      assert_not_equal(@@CLASSIFICATION_MARKER,session_plan[seq],"#{context}Expected the next event in the session plan to be an intervention.")
+      assert_equal(session_plan[seq],data["message"]["next_event"],"#{context}Expected next event in session plan to also be in next_event.")
+    end
+
+    def postIntervention(intervention_to_post, current_session_history, user_id)
+      url = "#{@@SERVER_URL}/experiment/CometHuntersVolcroweExperiment1/user/#{user_id}/session/#{@@FIRST_SESSION_ID}/intervention/#{intervention_to_post}"
+      uri = URI.parse(url)
+      http = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTP::Post.new(uri.request_uri)
+      response = http.request(request)
+      assert_equal("200",response.code, "Expected POST of intervention #{intervention_to_post} to succeed. Tried to post to #{url}. Message from server: #{response.code} - #{response.message}. Response body:\n #{response.body}")
+      JSON.parse(response.body)
+    end
+
+    def postCheckIntervention(data, interventions_available_count, interventions_seen_count, intervention_to_post, current_session_history, seq, session_plan, nextEvent, user_id, expected_cohort)
+      context = getContextForAssert "postCheckIntervention", session_plan, seq, current_session_history, nextEvent, data["message"]["intervention_time"]
+      assert_equal(CometHuntersVolcroweExperiment1::getExperimentName,data["message"]["experiment_name"],"#{context}Wrong experiment name.")
+      assert_equal(expected_cohort,data["message"]["cohort"],"#{context}Wrong cohort.")
+      assert_equal(user_id,data["message"]["user_id"],"#{context}Wrong user ID.")
+      assert(data["message"]["active"]==true,"#{context}Expected participant to be active.")
+      assert(data["message"]["excluded"]==false,"#{context}Expected participant not to be excluded.")
+      assert_nil(data["message"]["excluded_reason"],"#{context}Expected no exclusion reason")
+      assert_equal(interventions_available_count,data["message"]["interventions_available"].length,"#{context}Expected #{interventions_available_count} available interventions.")
+      assert(!data["message"]["interventions_available"].include?(intervention_to_post),"#{context}Expected that intervention no longer to be marked available.")
+      assert_equal(interventions_seen_count,data["message"]["interventions_seen"].length,"Expected #{interventions_seen_count} seen interventions.")
+      assert_equal(intervention_to_post,data["message"]["interventions_seen"].last,"#{context}Expected that intervention marked seen.")
+      assert_equal(Hash.new, data["message"]["original_session_plans"],"#{context}Expected no original session plans.")
+      assert_equal(Hash.new, data["message"]["session_histories"],"#{context}Expected no session histories.")
+      assert_equal(@@FIRST_SESSION_ID,data["message"]["current_session_id"], "#{context}Expected session ID not to change.")
+      assert_equal(current_session_history,data["message"]["current_session_history"],"#{context}Expected current session history to be updated.")
+      assert_equal(session_plan,data["message"]["current_session_plan"],"#{context}Expected session plan not to change.")
+      assert_equal(seq,data["message"]["seq_of_next_event"],"#{context}Expected session plan pointer to advance.")
+      assert_equal(false,data["message"]["intervention_time"],"#{context}Expected to be told that an intervention is not due next.")
+
+      if seq < session_plan.length
+        assert_equal(@@CLASSIFICATION_MARKER,data["message"]["next_event"],"#{context}Expected to be told that the next event is a classification.")
+        assert_equal(@@CLASSIFICATION_MARKER,session_plan[seq],"#{context}Expected the next event in the session plan is a classification..")
+        assert_equal(session_plan[seq],data["message"]["next_event"],"#{context}Expected next event in session plan to also be in next_event.")
+      else
+        # checking after the very last intervention
+        assert_equal(nil,data["message"]["next_event"],"#{context}Expected no next event.")
+      end
+
+    end
+
+    def getContextForAssert(method, session_plan, seq, current_session_history, nextEvent, intervention_time)
+      msg = "\n#{method}"
+      msg += "\nSession so far is:\n#{current_session_history}"
+      if not session_plan.nil?
+        msg += "\nSession plan is:\n#{session_plan}"
+        msg += "\nCurrent seq value is: #{seq} => #{session_plan[seq]}"
+      else
+        msg += "\nCurrent seq value is: #{seq}"
+      end
+      msg += "\nnextEvent is #{nextEvent}"
+      msg += "\nintervention_time is #{intervention_time ? "true" : "false"}\n"
+      msg
+    end
+
+    def advanceExpectationsAfterIntervention(data, seq, current_session_history, intervention_to_post, interventions_available_count, interventions_seen_count, session_plan, nextEvent)
+      current_session_history.push "intervention:#{intervention_to_post}"
+      interventions_seen_count = data["message"]["interventions_seen"].length
+      interventions_available_count = data["message"]["interventions_available"].length
+      seq += 1
+      nextEvent = session_plan[seq]
+      #print "\nAfter intervention, advancing expectations ready for position #{seq}: nextEvent is now expected to be #{session_plan[seq]} (actually #{nextEvent})\n"
+
+      return seq, interventions_available_count, interventions_seen_count, current_session_history, nextEvent
+    end
+
+    def advanceExpectationsAfterClassification(data, seq, session_plan, nextEvent, current_session_history, classification_id_index)
+      context = getContextForAssert "preAdvanceExpectationsAfterClassification", session_plan, seq, current_session_history, nextEvent, data["message"]["intervention_time"]
+      if current_session_history.nil?
+        current_session_history = []
+      end
+      current_session_history.push "classification:#{@@CLASSIFICATION_IDS[classification_id_index]}"
+      assert_equal(current_session_history,data["message"]["current_session_history"],"#{context}Expected current session history to be updated.")
+      if seq.nil?
+        session_plan = data["message"]["current_session_plan"]
+        seq = data["message"]["seq_of_next_event"]
+      else
+        seq += 1
+      end
+      #print "\nAfter classifying, advancing expectations ready for position #{seq}: nextEvent is now expected to be #{session_plan[seq]} (actually #{nextEvent})\n"
+      nextEvent = session_plan[seq]
+      classification_id_index += 1
+      interventions_seen_count = data["message"]["interventions_seen"].length
+      interventions_available_count = data["message"]["interventions_available"].length
+      return seq, classification_id_index, session_plan, nextEvent, current_session_history, interventions_available_count, interventions_seen_count
+    end
+##
+
+end
+
+## tests that could be added for robustness:
+
+# new session when one already exists for this user (i.e. resume)
+# full end to end across multiple sessions
+# past intervention when not expected
+# absent intervention when not expected
+# future intervention when not expected
+# classification when intervention was expected
+# classification after end of experiment
+# intervention after end of experiment


### PR DESCRIPTION
This is a combination of 18 commits.

Added Comet hunters experiment
Added tests: basic and end-to-end
Allow use of a different project when on staging
Test for all cohorts.
Update the end of experiment logic so that we never become inactive.
Ensure that intervention_time is always correct.
Improved error handling when tests fail due to network issues
Improve tests: "We're running out of elements!"
Add an extra sanity check to ensure we never run out of IDs again in the test.
